### PR TITLE
replaces pubsub from gql-subscriptions with redis pubsub and it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a standalone **Express + Apollo Server** application that provides a Gra
 
 - **GraphQL** endpoint at `/api/graphql`
 - **Subscriptions** via WebSockets (using `graphql-ws`)
+- **Redis PubSub** for handling real-time subscriptions
 - **Prisma** ORM for PostgreSQL (or any other supported DB)
 - **NextAuth**-compatible session validation
 - Custom resolvers, mutations, and subscriptions for real-time quiz/gaming logic
@@ -21,6 +22,7 @@ This is a standalone **Express + Apollo Server** application that provides a Gra
 - [Apollo Server](https://www.apollographql.com/docs/apollo-server/)
 - [GraphQL](https://graphql.org/)
 - [graphql-ws](https://github.com/enisdenjo/graphql-ws) for subscriptions
+- [Redis](https://redis.io/) for PubSub
 - [Prisma](https://www.prisma.io/) for database access
 - [NextAuth](https://next-auth.js.org/) for session handling
 - [WebSockets](https://developer.mozilla.org/docs/Web/API/WebSockets_API)
@@ -37,6 +39,8 @@ my-graphql-server/
  ┃ ┣ resolvers/
  ┃ ┃ ┗ index.ts           # Your GraphQL resolvers (Queries, Mutations, Subscriptions)
  ┃ ┣ schema.ts            # GraphQL type definitions (SDL)
+ ┃ ┣ lib/
+ ┃ ┃ ┗ redisPubSub.ts     # Redis PubSub configuration
  ┃ ┣ nextAuthOptions.ts   # (Optional) NextAuth config if you want to replicate it here
  ┃ ┗ index.ts             # Entry point (Express + ApolloServer setup)
  ┣ .env.example           # Example environment variables
@@ -52,7 +56,7 @@ my-graphql-server/
 1. **Clone** the repository:
 
    ```bash
-   git clone https://github.com/your-username/my-graphql-server.git
+   git clone https://github.com/dmitryjum/intelli-casino-gql-server.git
    cd intelli-casino-gql-server
    ```
 
@@ -101,6 +105,7 @@ my-graphql-server/
 
 ---
 
+
 ## Environment Variables
 
 | Variable          | Description                                            | Example                                  |
@@ -109,10 +114,16 @@ my-graphql-server/
 | `NEXTAUTH_SECRET` | Secret key for NextAuth session encryption/validation  | `my-secret-key`                          |
 | `CLIENT_ORIGIN`   | The origin (URL) of your front-end (CORS allowed)      | `http://localhost:3000`                  |
 | `PORT`            | Port on which the server will listen                   | `4000`                                   |
+| `REDIS_HOST`      | Host for your Redis server                             | `127.0.0.1`                              |
+| `REDIS_PORT`      | Port for your Redis server                             | `6379`                                   |
+| `REDIS_PASSWORD`  | Password for your Redis server (if any)                | `your-redis-password`                    |
 
 ---
 
 ## Usage Notes
+
+- **Redis PubSub**  
+  The server uses Redis for handling real-time subscriptions. Ensure your Redis server is running and accessible with the correct environment variables set for `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD`.
 
 - **Authentication**  
   The server uses [`getServerSession`](https://next-auth.js.org/configuration/nextjs) from **NextAuth** to validate the user’s session cookie. Make sure you have:
@@ -120,7 +131,7 @@ my-graphql-server/
   - The same or compatible session storage (e.g., the same `DATABASE_URL` if you store sessions in the DB).
 
 - **Subscriptions**  
-  Subscriptions are handled via `graphql-ws`.  
+  Subscriptions are handled via `graphql-ws` and Redis PubSub.  
   - For WebSocket connections, the path is `ws://<HOST>:<PORT>/api/graphql`.  
   - Make sure your front-end Apollo Client is configured with a `WebSocketLink` to that URL.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,13 @@
         "cors": "^2.8.5",
         "express": "^4.21.2",
         "graphql": "^16.10.0",
+        "graphql-redis-subscriptions": "^2.7.0",
         "graphql-scalars": "^1.24.0",
         "graphql-subscriptions": "^3.0.0",
         "graphql-tag": "^2.12.6",
         "graphql-type-json": "^0.3.2",
         "graphql-ws": "^6.0.0",
+        "ioredis": "^5.4.2",
         "keyword-extractor": "^0.0.28",
         "next-auth": "^4.24.11",
         "ws": "^8.18.0"
@@ -749,6 +751,11 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1403,6 +1410,14 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "peer": true
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -1552,6 +1567,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1863,6 +1886,17 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-redis-subscriptions": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.7.0.tgz",
+      "integrity": "sha512-IK4uCKx1UNhkcnG9lIqFWz9PpltSbuM8RygwGoB/e1HZMuKpAGeqqfHFeLKkQjjubvk4tAdUdx48AUkTAXJ17Q==",
+      "optionalDependencies": {
+        "ioredis": "^5.3.2"
+      },
+      "peerDependencies": {
+        "graphql-subscriptions": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      }
+    },
     "node_modules/graphql-scalars": {
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.24.0.tgz",
@@ -2000,6 +2034,50 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ioredis": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.2.tgz",
+      "integrity": "sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2084,6 +2162,16 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -2659,6 +2747,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -2919,6 +3026,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "graphql": "^16.10.0",
+    "graphql-redis-subscriptions": "^2.7.0",
     "graphql-scalars": "^1.24.0",
     "graphql-subscriptions": "^3.0.0",
     "graphql-tag": "^2.12.6",
     "graphql-type-json": "^0.3.2",
     "graphql-ws": "^6.0.0",
+    "ioredis": "^5.4.2",
     "keyword-extractor": "^0.0.28",
     "next-auth": "^4.24.11",
     "ws": "^8.18.0"

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -1,11 +1,11 @@
-import { PubSub, withFilter } from 'graphql-subscriptions'
+import { withFilter } from 'graphql-subscriptions'
 import { IResolvers } from '@graphql-tools/utils';
 import GraphQLJSON from 'graphql-type-json';
 import { GraphQLDateTime } from 'graphql-scalars';
 import { queryResolvers } from './queryResolvers';
 import { mutationResolvers } from './mutationResolvers';
+import { pubsub } from '@/src/lib/redisPubSub';
 
-export const pubsub = new PubSub();
 const GAME_UPDATED = 'GAME_UPDATED';
 
 const resolvers: IResolvers = {

--- a/src/graphql/resolvers/mutationResolvers.ts
+++ b/src/graphql/resolvers/mutationResolvers.ts
@@ -3,7 +3,7 @@ import { OPEN_DURATION } from '@/src/lib/constants';
 import { generateBlankedAnswer } from '@/src/lib/utils';
 import { GraphQLError } from 'graphql';
 import { getGameUpdateData } from '@/src/lib/utils';
-import { pubsub } from '../resolvers/index'; // shared resolvers have to use the same PubSub instance for sockets to work
+import { pubsub } from '@/src/lib/redisPubSub';
 
 const prisma = new PrismaClient();
 const GAME_UPDATED = 'GAME_UPDATED';

--- a/src/lib/redisPubSub.ts
+++ b/src/lib/redisPubSub.ts
@@ -1,0 +1,17 @@
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import Redis, { RedisOptions } from 'ioredis';
+
+const options: RedisOptions = {
+  host: process.env.REDIS_HOST || '127.0.0.1',
+  port: parseInt(process.env.REDIS_PORT || '6379', 10),
+  password: process.env.REDIS_PASSWORD || '',
+  retryStrategy: (times: number) => {
+    // reconnect after
+    return Math.min(times * 50, 2000);
+  }
+};
+
+export const pubsub = new RedisPubSub({
+  publisher: new Redis(options),
+  subscriber: new Redis(options),
+});


### PR DESCRIPTION
Summary
This PR replaces the in-memory PubSub from graphql-subscriptions with RedisPubSub from graphql-redis-subscriptions, enabling scalable real-time subscription events across multiple server instances. The code now connects to a Redis instance (local or hosted) for pub/sub messaging.

Changes
Installed graphql-redis-subscriptions and ioredis dependencies.
Created a redisPubSub.ts file to configure RedisPubSub with environment variables (REDIS_HOST, REDIS_PORT, REDIS_PASSWORD).
Updated resolvers to use redisPubSub instead of the default PubSub.
Adjusted the .env and README.md to document Redis environment variables.