### PR TITLE
Dockerization and config for ECR deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Ignore node_modules (since we install them fresh in Docker)
+node_modules
+
+# Ignore built files (since Docker builds them)
+dist
+
+# Ignore environment files (to prevent secrets leakage)
+.env
+.env.local
+.env.production
+.env.docker
+
+
+# Ignore logs and cache files
+npm-debug.log
+logs
+*.log
+
+# Ignore Docker artifacts
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .env
 .env*.local
 .env*.production
+.env*.docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use an official Node.js runtime as a parent image
+FROM node:23-alpine3.20
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json first for dependency caching
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install --omit=dev
+
+# Copy the rest of the application files
+COPY . .
+
+# Build the TypeScript code
+RUN npm run build
+
+# Generate Prisma client for Linux
+RUN npx prisma generate
+
+# Expose the port your Express server runs on (e.g., 4000)
+EXPOSE 4000
+
+# Start the server using the compiled JavaScript files
+CMD ["node", "-r", "module-alias/register", "dist/src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN npm install
 
 # Copy all sources and build
 COPY . .
-RUN npm run build
 RUN npx prisma generate
+RUN npm run build
 
 # Final Stage
 FROM node:23-alpine3.20

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ my-graphql-server/
 
 ---
 
+## Running with Docker
+
+1. **Create** a Docker-specific environment file named `.env.docker` in the project root. This file should contain your production-style environment variables that use `host.docker.internal` for local services. For example:
+
+   ```bash
+   # .env.docker
+   DATABASE_URL=postgresql://dmitryjum:dmitryjum@host.docker.internal:5432/intelli_casino?schema=public
+   REDIS_HOST=host.docker.internal
+
+2. Build the Docker image:
+   ```bash
+   docker build -t intelli-casino-express .
+
+3. **Run** the Docker container and inject the Docker environment file:
+   ```bash
+   docker run -b 4000:4000 --env-file .env.docker intelli-casino-express
+
+This setup ensures that your application running insde Docker connects to your local PostgreSQL and Redis instances via `host.docker.internal`
+
 <!-- ## Deployment
 
 You can deploy this app on any Node-friendly host that supports WebSockets, such as:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@prisma/client": "^6.2.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "graphql": "^16.10.0",
         "graphql-redis-subscriptions": "^2.7.0",
@@ -25,6 +26,7 @@
         "graphql-ws": "^6.0.0",
         "ioredis": "^5.4.2",
         "keyword-extractor": "^0.0.28",
+        "module-alias": "^2.2.3",
         "next-auth": "^4.24.11",
         "ws": "^8.18.0"
       },
@@ -1613,6 +1615,17 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dset": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
@@ -2291,6 +2304,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
     },
     "node_modules/ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "start:build": "node dist/src/index.js",
+    "start:build": "node -r module-alias/register dist/src/index.js",
     "dev": "nodemon --watch './**/*.ts' --exec 'ts-node -r tsconfig-paths/register src/index.ts'",
     "start": "ts-node -r tsconfig-paths/register src/index.ts",
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
     "prisma:studio": "npx prisma studio"
+  },
+  "_moduleAliases": {
+    "@": "dist"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +26,7 @@
     "@prisma/client": "^6.2.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "graphql": "^16.10.0",
     "graphql-redis-subscriptions": "^2.7.0",
@@ -33,6 +37,7 @@
     "graphql-ws": "^6.0.0",
     "ioredis": "^5.4.2",
     "keyword-extractor": "^0.0.28",
+    "module-alias": "^2.2.3",
     "next-auth": "^4.24.11",
     "ws": "^8.18.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { authOptions } from '@/src/lib/nextauth';
 import { getServerSession } from 'next-auth'
 import cookieParser from 'cookie-parser';
 import { GraphQLError } from 'graphql';
+import dotenv from 'dotenv';
+dotenv.config({ path: process.env.NODE_ENV === 'production' ? '.env.production' : '.env.local' });
 
 (async () => {
   const schema = makeExecutableSchema({


### PR DESCRIPTION
- Updated Dockerfile to implement a multi-stage build which reduces the final image size from ~1.5GB to ~858MB by copying only the necessary artifacts (compiled code, production dependencies, and Prisma client) into the final image.
- Retained Prisma generation step in the build stage; binaryTargets are omitted for now, to be added later if production issues arise.
- Ensured that the server is launched using the compiled code with module alias support.
- This setup improves build efficiency and maintains a lean production image, making it suitable for ECR/ECS deployments.